### PR TITLE
Fix token YAML tag and debug log

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type ExcludeCertRule struct {
 // It includes webhook settings, scan intervals, network options, and more.
 type Config struct {
 	WebhookURL          string            `yaml:"webhook_url"`
-	Token               string            `yaml:"ultrapki_token",omitempty"`
+	Token               string            `yaml:"ultrapki_token,omitempty"`
 	ScanIntervalSeconds int               `yaml:"scan_interval_seconds"`
 	ScanThrottleDelayMs int               `yaml:"scan_throttle_delay_ms"`
 	EnableIPv6Discovery bool              `yaml:"enable_ipv6_discovery"`

--- a/internal/scanner/smtp.go
+++ b/internal/scanner/smtp.go
@@ -99,7 +99,7 @@ func smtpProtocolHandler(ip, hostname string, port int) bool {
 		return true // handled, but failed
 	}
 	logutil.DebugLog("STARTTLS scan successful for %s:%d", ip, port)
-	logutil.DebugLog("Certificate for %s:%d: %w", ip, port, result)
+	logutil.DebugLog("Certificate for %s:%d: %+v", ip, port, result)
 	// Filter certificates before sending to webhook
 	excludeCerts := shared.Config.ExcludeCerts
 	result.Certificates = filterCerts(decodeBase64Certs(result.Certificates), excludeCerts)


### PR DESCRIPTION
## Summary
- fix YAML tag for `ultrapki_token` in config
- use `%+v` instead of `%w` when logging SMTP certificates

## Testing
- `GOTOOLCHAIN=local go vet ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_684417fa1688832b90d184c3a3024454