### PR TITLE
Fix typo in discovery comment

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -219,7 +219,7 @@ func sendICMPv6Echo(dstIP net.IP, ifaceName string) (string, error) {
 
 // sendNDPSolicitation sends a Neighbor Solicitation to a target address and returns the response IP (or empty string).
 func sendNDPSolicitation(dstIP net.IP, ifaceName string) (string, error) {
-	// Not implemented yet because it would require ths tool to run as root (raw sockets)
+	// Not implemented yet because it would require this tool to run as root (raw sockets)
 	return "", nil
 }
 


### PR DESCRIPTION
## Summary
- fix comment typo in `internal/discovery/discovery.go`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go fmt ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684419664fb4832b9f94fa86816bb9fb